### PR TITLE
LIBFCREPO-887. Create Fuseki docker image.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Build images:
 docker build -t docker.lib.umd.edu/fcrepo-postgres postgres
 docker build -t docker.lib.umd.edu/fcrepo-activemq activemq
 docker build -t docker.lib.umd.edu/fcrepo-solr-fedora4 solr-fedora4
+docker build -t docker.lib.umd.edu/fcrepo-fuseki fuseki
 ```
 
 Deploy the stack:
@@ -27,6 +28,7 @@ docker stack deploy --with-registry-auth -c umd-fcrepo.yml umd-fcrepo
 
 * ActiveMQ admin console: <http://localhost:8161/admin>
 * Solr admin console: <http://localhost:8983/solr/#/>
+* Fuseki admin console: <http://localhost:3030/>
 
 ## Individual Images
 
@@ -36,3 +38,4 @@ files for each image for more information:
 * [PostgreSQL](postgres/README.md)
 * [ActiveMQ](activemq/README.md)
 * [Solr (fedora4 Core)](solr-fedora4/README.md)
+* [Fuseki](fuseki/README.md)

--- a/activemq/.dockerignore
+++ b/activemq/.dockerignore
@@ -1,0 +1,2 @@
+.dockerignore
+Dockerfile

--- a/fuseki/.dockerignore
+++ b/fuseki/.dockerignore
@@ -1,0 +1,2 @@
+.dockerignore
+Dockerfile

--- a/fuseki/Dockerfile
+++ b/fuseki/Dockerfile
@@ -1,0 +1,24 @@
+# generic Fuseki image
+FROM openjdk:8 AS fuseki
+
+ENV FUSEKI_VERSION 2.3.1
+ENV FUSEKI_HOME /opt/apache-jena-fuseki-${FUSEKI_VERSION}
+ENV FUSEKI_BASE /var/opt/fuseki
+ENV FUSEKI_DATA_DIR $FUSEKI_BASE/databases
+
+RUN curl -Ls https://archive.apache.org/dist/jena/binaries/apache-jena-fuseki-${FUSEKI_VERSION}.tar.gz \
+    | tar xvzf - --directory /opt
+
+RUN mkdir -p "$FUSEKI_BASE"/{DB,logs}
+
+VOLUME /var/opt/fuseki
+EXPOSE 3030
+
+WORKDIR $FUSEKI_HOME
+CMD ["./fuseki", "run"]
+
+# UMD-specific configuration
+FROM fuseki
+
+COPY configuration/* $FUSEKI_BASE/configuration/
+COPY shiro.ini $FUSEKI_BASE/

--- a/fuseki/README.md
+++ b/fuseki/README.md
@@ -1,0 +1,43 @@
+# Fuseki Image for umd-fcrepo-docker
+
+Built from the [OpenJDK 8 Docker base image](https://hub.docker.com/_/openjdk),
+with [Fuseki 2.3.1](https://jena.apache.org/download/index.cgi).
+
+[Dockerfile](Dockerfile)
+
+Create a persistant data volume, if needed:
+
+```bash
+docker volume create fcrepo-fuseki-data
+```
+
+Build and run this image.
+
+```bash
+cd fuseki
+docker build -t docker.lib.umd.edu/fcrepo-fuseki .
+docker run -it --rm --name fcrepo-fuseki \
+    -p 3030:3030 \
+    -v fcrepo-fuseki-data:/var/opt/fuseki \
+    docker.lib.umd.edu/fcrepo-fuseki
+```
+
+The Fuseki admin console will be at <http://localhost:3030/>
+
+There will be two datasets configured:
+
+* fedora4
+* fcrepo-audit
+
+## Building a Plain Fuseki Image
+
+This Dockerfile can also be used to build a plain Fuseki image (i.e.,
+without the dataset configuration of Shiro configuration). To do this,
+specify a build target of `fuseki`:
+
+```bash
+docker build --target fuseki -t fuseki .
+docker run -it --rm -p 3030:3030 -v $(pwd)/data:/var/opt/fuseki fuseki
+```
+
+

--- a/fuseki/configuration/fcrepo-audit.ttl
+++ b/fuseki/configuration/fcrepo-audit.ttl
@@ -1,0 +1,21 @@
+@prefix :      <http://base/#> .
+@prefix tdb:   <http://jena.hpl.hp.com/2008/tdb#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix ja:    <http://jena.hpl.hp.com/2005/11/Assembler#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix fuseki: <http://jena.apache.org/fuseki#> .
+
+:service_tdb_all  a                   fuseki:Service ;
+        rdfs:label                    "TDB fcrepo-audit" ;
+        fuseki:dataset                :tdb_dataset_readwrite ;
+        fuseki:name                   "fcrepo-audit" ;
+        fuseki:serviceQuery           "query" , "sparql" ;
+        fuseki:serviceReadGraphStore  "get" ;
+        fuseki:serviceReadWriteGraphStore
+                "data" ;
+        fuseki:serviceUpdate          "update" ;
+        fuseki:serviceUpload          "upload" .
+
+:tdb_dataset_readwrite
+        a             tdb:DatasetTDB ;
+        tdb:location  "/var/opt/fuseki/databases/fcrepo-audit" .

--- a/fuseki/configuration/fedora4.ttl
+++ b/fuseki/configuration/fedora4.ttl
@@ -1,0 +1,21 @@
+@prefix :      <http://base/#> .
+@prefix tdb:   <http://jena.hpl.hp.com/2008/tdb#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix ja:    <http://jena.hpl.hp.com/2005/11/Assembler#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix fuseki: <http://jena.apache.org/fuseki#> .
+
+:service_tdb_all  a                   fuseki:Service ;
+        rdfs:label                    "TDB fedora4" ;
+        fuseki:dataset                :tdb_dataset_readwrite ;
+        fuseki:name                   "fedora4" ;
+        fuseki:serviceQuery           "query" , "sparql" ;
+        fuseki:serviceReadGraphStore  "get" ;
+        fuseki:serviceReadWriteGraphStore
+                "data" ;
+        fuseki:serviceUpdate          "update" ;
+        fuseki:serviceUpload          "upload" .
+
+:tdb_dataset_readwrite
+        a             tdb:DatasetTDB ;
+        tdb:location  "/var/opt/fuseki/databases/fedora4" .

--- a/fuseki/shiro.ini
+++ b/fuseki/shiro.ini
@@ -1,0 +1,37 @@
+# Licensed under the terms of http://www.apache.org/licenses/LICENSE-2.0
+
+[main]
+# Development
+ssl.enabled = false 
+
+plainMatcher=org.apache.shiro.authc.credential.SimpleCredentialsMatcher
+#iniRealm=org.apache.shiro.realm.text.IniRealm 
+iniRealm.credentialsMatcher = $plainMatcher
+
+localhostFilter=org.apache.jena.fuseki.authz.LocalhostFilter
+
+[users]
+# Implicitly adds "iniRealm =  org.apache.shiro.realm.text.IniRealm"
+admin=admin
+
+[roles]
+
+[urls]
+## Control functions open to anyone
+/$/status = anon
+/$/ping   = anon
+
+## and the rest are restricted to localhost.
+#/$/** = localhostFilter
+
+## If you want simple, basic authentication user/password
+## on the operations, 
+##    1 - set a better password in [users] above.
+##    2 - comment out the "/$/** = localhost" line and use:
+## "/$/** = authcBasic,user[admin]"
+
+## or to allow any access.
+/$/** = anon
+
+# Everything else
+/**=anon

--- a/postgres/.dockerignore
+++ b/postgres/.dockerignore
@@ -1,0 +1,2 @@
+.dockerignore
+Dockerfile

--- a/umd-fcrepo.yml
+++ b/umd-fcrepo.yml
@@ -20,7 +20,14 @@ services:
       - solr-fedora4-data:/var/opt/solr
     ports:
       - 8983:8983
+  fuseki:
+    image: docker.lib.umd.edu/fcrepo-fuseki
+    volumes:
+      - fuseki-data:/var/opt/fuseki
+    ports:
+      - 3030:3030
 volumes:
   postgres-data:
   activemq-data:
   solr-fedora4-data:
+  fuseki-data:


### PR DESCRIPTION
- Implemented as a staged build, so you can build just Fuseki, or Fuseki with the umd-fcrepo-specific configuration and datasets.
- Included Fuseki in the full stack deployment configuration.
- Added .dockerignore files.

https://issues.umd.edu/browse/LIBFCREPO-887