### PR TITLE
LIBFCREPO-906. Set "-XX:MaxRAMPercentage" property using JAVA_OPTIONS 

### DIFF
--- a/fuseki/Dockerfile
+++ b/fuseki/Dockerfile
@@ -28,5 +28,8 @@ CMD ["./fuseki", "run"]
 # UMD-specific configuration
 FROM fuseki
 
+# Allow JRE to use up to 75% of the RAM in the container
+ENV JAVA_OPTIONS=-XX:MaxRAMPercentage=75.0
+
 COPY configuration/* $FUSEKI_BASE/configuration/
 COPY shiro.ini $FUSEKI_BASE/


### PR DESCRIPTION
Set the "-XX:MaxRAMPercentage" Java system property using the
JAVA_OPTIONS environment variable. The JAVA_OPTIONS environment variable
is used by the Fuseki start script to set Java system properties.

Setting the "-XX:MaxRAMPercentage" to 75%, so that the JRE will use
up to 75% of the RAM provided by the container (instead of the default
25%).

This property is preferred to setting "-Xmx" and hard-coding an explicit
amount of RAM because it does not require coordinating with the
resource limits in the Kubernetes configuration.

https://issues.umd.edu/browse/LIBFCREPO-906