### PR TITLE
LIBFCREPO-909. Implement update triplestore index.

### DIFF
--- a/activemq/Dockerfile
+++ b/activemq/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /var/jars
 # fetch JARs required for running the Camel routes, but exclude the org.slf4j
 # group to avoid a SLF4J conflict with ActiveMQ's own bundled SLF4J library; see
 # also http://www.slf4j.org/codes.html#log4jDelegationLoop
-RUN mvn dependency:copy-dependencies -DexcludeGroupIds=org.slf4j
+RUN mvn dependency:copy-dependencies -DexcludeGroupIds=org.slf4j,ch.qos.logback
 
 FROM openjdk:8u265-jdk-buster
 

--- a/activemq/conf/activemq.xml
+++ b/activemq/conf/activemq.xml
@@ -140,6 +140,14 @@
   <import resource="jetty.xml"/>
 
   <!-- Camel-based message routing -->
+  <!-- common Authorization header generator -->
+  <bean id="addBearerAuthorization" class="edu.umd.lib.camel.processors.AddBearerAuthorizationProcessor">
+    <property name="authTokenService">
+      <bean class="edu.umd.lib.fcrepo.AuthTokenService">
+        <property name="secret" value="${JWT_SECRET}"/>
+      </bean>
+    </property>
+  </bean>
   <import resource="camel/routes.xml"/>
   <import resource="camel/audit.xml"/>
   <import resource="camel/fixity.xml"/>

--- a/activemq/conf/camel/audit.xml
+++ b/activemq/conf/camel/audit.xml
@@ -34,13 +34,13 @@
           </setHeader>
         </when>
         <when>
-          <simple>${headers.CamelFcrepoEventName} == "modify binary"</simple>
+          <simple>${headers.CamelFcrepoEventName} == "update binary"</simple>
           <setHeader headerName="CamelAuditEventType">
             <constant>http://fedora.info/definitions/v4/audit#contentModification</constant>
           </setHeader>
         </when>
         <when>
-          <simple>${headers.CamelFcrepoEventName} == "modify RDF"</simple>
+          <simple>${headers.CamelFcrepoEventName} == "update RDF"</simple>
           <setHeader headerName="CamelAuditEventType">
             <constant>http://fedora.info/definitions/v4/audit#metadataModification</constant>
           </setHeader>

--- a/activemq/conf/camel/fixity.xml
+++ b/activemq/conf/camel/fixity.xml
@@ -71,9 +71,7 @@
       <setHeader headerName="CamelHttpMethod">
         <constant>HEAD</constant>
       </setHeader>
-      <setHeader headerName="Authorization">
-        <simple>Bearer ${sysenv.CAMEL_AUTH_TOKEN}</simple>
-      </setHeader>
+      <process ref="addBearerAuthorization"/>
       <to uri="http4:fcrepo"/>
       <filter>
         <simple>${header.Link} contains '&lt;http://www.w3.org/ns/ldp#NonRDFSource>;rel="type"'</simple>
@@ -95,11 +93,11 @@
         </setBody>
         <log loggingLevel="DEBUG" message="Fixity check request sent to ${header.CamelHttpUri}"/>
         <to uri="http4:fcrepo"/>
+        <log loggingLevel="DEBUG" message="Fixity check raw result: ${in.body}"/>
         <choice>
           <when>
             <xpath>/rdf:RDF/rdf:Description/premis:hasEventOutcome[text()='SUCCESS']</xpath>
             <log loggingLevel="INFO" message="Fixity check succeeded for ${header.CamelFcrepoUri}"/>
-            <log loggingLevel="DEBUG" message="Fixity check raw result: ${in.body}"/>
             <to uri="direct:fixity.success"/>
           </when>
           <otherwise>

--- a/activemq/conf/camel/routes.xml
+++ b/activemq/conf/camel/routes.xml
@@ -95,7 +95,7 @@
             || ${header.CamelFcrepoEventType} contains "https://www.w3.org/ns/activitystreams#Update"
           </simple>
           <setHeader headerName="CamelFcrepoEventName">
-            <constant>modify</constant>
+            <constant>update</constant>
           </setHeader>
         </when>
       </choice>

--- a/activemq/conf/camel/triplestore.xml
+++ b/activemq/conf/camel/triplestore.xml
@@ -7,13 +7,7 @@
     <constructor-arg value="${REPO_EXTERNAL_URL}"/>
   </bean>
 
-  <bean id="addBearerAuthorization" class="edu.umd.lib.camel.processors.AddBearerAuthorizationProcessor">
-    <property name="authTokenService">
-      <bean class="edu.umd.lib.fcrepo.AuthTokenService">
-        <property name="secret" value="${JWT_SECRET}"/>
-      </bean>
-    </property>
-  </bean>
+  <bean id="descriptionURI" class="edu.umd.lib.camel.processors.DescriptionURI"/>
 
   <camelContext xmlns="http://camel.apache.org/schema/spring" id="Triplestore" streamCache="true">
     <route id="edu.umd.lib.camel.routes.TriplestoreIndexing">
@@ -24,14 +18,18 @@
           <to uri="direct:index.triplestore.create"/>
         </when>
         <when>
+          <simple>${header.CamelFcrepoEventName} starts with "update"</simple>
+          <to uri="direct:index.triplestore.update"/>
+        </when>
+        <when>
           <simple>${header.CamelFcrepoEventName} starts with "delete"</simple>
           <to uri="direct:index.triplestore.delete"/>
         </when>
       </choice>
     </route>
 
-    <route id="edu.umd.lib.camel.routes.IndexTriplestoreCreate">
-      <from uri="direct:index.triplestore.create"/>
+    <route id="edu.umd.lib.camel.routes.GetRDF">
+      <from uri="direct:getRDF"/>
       <!-- generate a Bearer auth token for the Authorization header -->
       <process ref="addBearerAuthorization"/>
       <!-- check whether this is a binary or not -->
@@ -42,11 +40,14 @@
         <constant>HEAD</constant>
       </setHeader>
       <!-- send the HEAD request to fcrepo -->
+      <log loggingLevel="DEBUG" message="HEAD ${header.CamelHttpUri}"/>
       <to uri="http4:fcrepo"/>
+      <!-- parse the Link headers to check for rel="describedby" -->
+      <process ref="descriptionURI"/>
       <filter>
-        <simple>${header.Link} contains '&lt;http://www.w3.org/ns/ldp#NonRDFSource>;rel="type"'</simple>
+        <simple>${header.DescribedBy}</simple>
         <setHeader headerName="CamelHttpUri">
-          <simple>${sysenv.REPO_INTERNAL_URL}${header.CamelFcrepoPath}/fcr:metadata</simple>
+          <header>DescribedBy</header>
         </setHeader>
       </filter>
       <!-- get the RDF to insert into the triplestore -->
@@ -64,8 +65,30 @@
       </setHeader>
       <log loggingLevel="DEBUG" message="GET ${header.CamelHttpUri}"/>
       <to uri="http4:fcrepo"/>
+    </route>
+
+    <route id="edu.umd.lib.camel.routes.IndexTriplestoreCreate">
+      <from uri="direct:index.triplestore.create"/>
+      <to uri="direct:getRDF"/>
+      <!-- insert into the triplestore -->
       <setBody>
         <simple>INSERT DATA {\n${body}}</simple>
+      </setBody>
+      <to uri="direct:index.triplestore.http"/>
+    </route>
+
+    <route id="edu.umd.lib.camel.routes.IndexTriplestoreUpdate">
+      <from uri="direct:index.triplestore.update"/>
+      <to uri="direct:getRDF"/>
+      <!-- replace current triples in triplestore -->
+      <setBody>
+        <simple><![CDATA[
+DELETE { <${header.CamelFcrepoUri}> ?p ?o }
+INSERT {
+${body}
+}
+WHERE  { <${header.CamelFcrepoUri}> ?p ?o }
+        ]]></simple>
       </setBody>
       <to uri="direct:index.triplestore.http"/>
     </route>


### PR DESCRIPTION
Made the addBearerAuthorization a common bean that can be shared across the routes.

https://issues.umd.edu/browse/LIBFCREPO-909