### PR TITLE
LIBFCREPO-910. Added an index and reindex queue.

### DIFF
--- a/activemq/conf/activemq.xml
+++ b/activemq/conf/activemq.xml
@@ -149,6 +149,7 @@
     </property>
   </bean>
   <import resource="camel/routes.xml"/>
+  <import resource="camel/indexing.xml"/>
   <import resource="camel/audit.xml"/>
   <import resource="camel/fixity.xml"/>
   <import resource="camel/triplestore.xml"/>

--- a/activemq/conf/camel/indexing.xml
+++ b/activemq/conf/camel/indexing.xml
@@ -1,0 +1,37 @@
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+  http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
+
+  <camelContext xmlns="http://camel.apache.org/schema/spring" id="Indexing" streamCache="true">
+    <route id="edu.umd.lib.camel.routes.indexing.Intake">
+      <from uri="activemq:queue:index"/>
+      <choice>
+        <when>
+          <header>CamelFcrepoIndexingDestinations</header>
+          <log loggingLevel="DEBUG" message="Sending to ${header.CamelFcrepoIndexingDestinations}"/>
+          <recipientList ignoreInvalidEndpoints="true" parallelProcessing="true">
+            <header>CamelFcrepoIndexingDestinations</header>
+          </recipientList>
+        </when>
+        <otherwise>
+          <log loggingLevel="DEBUG" message="Sending to all indexing destinations"/>
+          <multicast parallelProcessing="true">
+            <to uri="activemq:queue:fedoratriplestore"/>
+            <to uri="activemq:queue:fedorasolr"/>
+          </multicast>
+        </otherwise>
+      </choice>
+    </route>
+
+    <route id="edu.umd.lib.camel.routes.indexing.Reindex">
+      <from uri="activemq:queue:reindex"/>
+      <log loggingLevel="INFO" message="Reindexing resource ${header.CamelFcrepoUri}"/>
+      <!-- a request to reindex should be treated the same as if the resource was updated -->
+      <setHeader headerName="CamelFcrepoEventName">
+        <constant>update</constant>
+      </setHeader>
+      <to uri="activemq:queue:index"/>
+    </route>
+  </camelContext>
+</beans>

--- a/activemq/conf/camel/routes.xml
+++ b/activemq/conf/camel/routes.xml
@@ -133,8 +133,7 @@
           <simple>${headers.CamelFcrepoBinary}</simple>
           <to uri="direct:binary"/>
         </filter>
-        <to uri="activemq:queue:fedorasolr"/>
-        <to uri="activemq:queue:fedoratriplestore"/>
+        <to uri="activemq:queue:index"/>
         <to uri="activemq:queue:fedoraaudit"/>
       </multicast>
     </route>

--- a/activemq/conf/camel/triplestore.xml
+++ b/activemq/conf/camel/triplestore.xml
@@ -10,6 +10,12 @@
   <bean id="descriptionURI" class="edu.umd.lib.camel.processors.DescriptionURI"/>
 
   <camelContext xmlns="http://camel.apache.org/schema/spring" id="Triplestore" streamCache="true">
+    <!--
+    Expected headers:
+    * CamelFcrepoEventName
+    Expected body format:
+    * (None)
+    -->
     <route id="edu.umd.lib.camel.routes.TriplestoreIndexing">
       <from uri="activemq:queue:fedoratriplestore"/>
       <choice>
@@ -28,6 +34,17 @@
       </choice>
     </route>
 
+    <!--
+    Expected headers:
+    * CamelFcrepoUser
+    * CamelFcrepoPath
+    Expected body format:
+    * (None)
+    Expected environment variables:
+    * REPO_INTERNAL_URL
+    Expected beans:
+    * repoExternalURL
+    -->
     <route id="edu.umd.lib.camel.routes.GetRDF">
       <from uri="direct:getRDF"/>
       <!-- generate a Bearer auth token for the Authorization header -->
@@ -50,7 +67,7 @@
           <header>DescribedBy</header>
         </setHeader>
       </filter>
-      <!-- get the RDF to insert into the triplestore -->
+      <!-- get the current RDF representation of the resource as N-Triples -->
       <setHeader headerName="CamelHttpMethod">
         <constant>GET</constant>
       </setHeader>
@@ -67,6 +84,13 @@
       <to uri="http4:fcrepo"/>
     </route>
 
+    <!--
+    Expected headers:
+    * CamelFcrepoUser
+    * CamelFcrepoPath
+    Expected body format:
+    * N-Triples
+    -->
     <route id="edu.umd.lib.camel.routes.IndexTriplestoreCreate">
       <from uri="direct:index.triplestore.create"/>
       <to uri="direct:getRDF"/>
@@ -77,6 +101,12 @@
       <to uri="direct:index.triplestore.http"/>
     </route>
 
+    <!--
+    Expected headers:
+    * CamelFcrepoUri
+    Expected body format:
+    * N-Triples
+    -->
     <route id="edu.umd.lib.camel.routes.IndexTriplestoreUpdate">
       <from uri="direct:index.triplestore.update"/>
       <to uri="direct:getRDF"/>
@@ -84,15 +114,18 @@
       <setBody>
         <simple><![CDATA[
 DELETE { <${header.CamelFcrepoUri}> ?p ?o }
-INSERT {
-${body}
-}
-WHERE  { <${header.CamelFcrepoUri}> ?p ?o }
-        ]]></simple>
+INSERT {\n${body}}
+WHERE {}]]></simple>
       </setBody>
       <to uri="direct:index.triplestore.http"/>
     </route>
 
+    <!--
+    Expected headers:
+    * CamelFcrepoUri
+    Expected body format:
+    * N-Triples
+    -->
     <route id="edu.umd.lib.camel.routes.IndexTriplestoreDelete">
       <from uri="direct:index.triplestore.delete"/>
       <setBody>
@@ -105,6 +138,14 @@ WHERE  { <${header.CamelFcrepoUri}> ?p ?o }
       <to uri="direct:index.triplestore.http"/>
     </route>
 
+    <!--
+    Expected headers:
+    * (None)
+    Expected body format:
+    * N-Triples
+    Expected environment variables:
+    * INDEX_TRIPLESTORE_UPDATE_URI
+    -->
     <route id="edu.umd.lib.camel.routes.IndexTriplestoreHttp">
       <from uri="direct:index.triplestore.http"/>
       <removeHeaders pattern="*"/>
@@ -117,6 +158,7 @@ WHERE  { <${header.CamelFcrepoUri}> ?p ?o }
       <setHeader headerName="Content-Type">
         <constant>application/sparql-update</constant>
       </setHeader>
+      <log loggingLevel="DEBUG" message="SPARQL Update Query: ${body}"/>
       <to uri="http4:triplestore"/>
     </route>
   </camelContext>


### PR DESCRIPTION
These queues relay to either the destinations named in the CamelFcrepoIndexingDestinations header, or to all indexing queues (current, fedoratriplestore and fedorasolr).

https://issues.umd.edu/browse/LIBFCREPO-910