### PR TITLE
LIBFCREPO-912. Enable the fixity log file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ docker build -t docker.lib.umd.edu/fcrepo-activemq activemq
 docker build -t docker.lib.umd.edu/fcrepo-solr-fedora4 solr-fedora4
 docker build -t docker.lib.umd.edu/fcrepo-fuseki fuseki
 docker build -t docker.lib.umd.edu/fcrepo-fixity fixity
+docker build -t docker.lib.umd.edu/fcrepo-mail mail
 ```
 
 Export environment variables (for the repository container):
@@ -62,6 +63,17 @@ Multiple command line options can be provided to the script, i.e.:
 docker run docker.lib.umd.edu/fcrepo-fixity:latest --server host.docker.internal:61613 --age P6M
 ```
 
+### Email Notifications
+
+This stack uses a debugging SMTP server implementation as the destination server
+for outgoing fixity failure notification emails. This server uses the Python [aiosmtpd]
+library, and does not actually deliver the emails. Instead, it just echoes the contents
+(headers and body) to STDOUT. To monitor these emails, use:
+
+```bash
+docker service logs -f umd-fcrepo_mail
+```
+
 ### Application URLs
 
 * ActiveMQ admin console: <http://localhost:8161/admin>
@@ -79,5 +91,7 @@ files for each image for more information:
 * [ActiveMQ](activemq/README.md)
 * [Solr (fedora4 Core)](solr-fedora4/README.md)
 * [Fuseki](fuseki/README.md)
+* [Mail](mail/README.md)
 
 [umd-fcrepo-webapp]: https://github.com/umd-lib/umd-fcrepo-webapp
+[aiosmtpd]: https://aiosmtpd.readthedocs.io/en/latest/README.html

--- a/activemq/Dockerfile
+++ b/activemq/Dockerfile
@@ -32,6 +32,7 @@ COPY conf/ $ACTIVEMQ_HOME/conf/
 COPY env $ACTIVEMQ_HOME/bin/env
 
 VOLUME /var/opt/activemq
+VOLUME /var/log/fixity
 EXPOSE 61613
 EXPOSE 61616
 EXPOSE 8161

--- a/activemq/README.md
+++ b/activemq/README.md
@@ -5,7 +5,7 @@ with [ActiveMQ 5.16.0](http://activemq.apache.org/activemq-5160-release).
 
 [Dockerfile](Dockerfile)
 
-Create a persistant data volume, if needed:
+Create a persistent data volume, if needed:
 
 ```bash
 docker volume create fcrepo-activemq-data

--- a/activemq/conf/activemq.xml
+++ b/activemq/conf/activemq.xml
@@ -148,6 +148,10 @@
       </bean>
     </property>
   </bean>
+  <!-- externally-facing repository URL -->
+  <bean id="repoExternalURL" class="java.net.URL">
+    <constructor-arg value="${REPO_EXTERNAL_URL}"/>
+  </bean>
   <import resource="camel/routes.xml"/>
   <import resource="camel/indexing.xml"/>
   <import resource="camel/audit.xml"/>

--- a/activemq/conf/camel/fixity.xml
+++ b/activemq/conf/camel/fixity.xml
@@ -136,7 +136,7 @@
       <setHeader headerName="CamelSparqlQueryBinding-URI-eventUri">
         <header>CamelAuditEventUri</header>
       </setHeader>
-      <log loggingLevel="INFO" message="Event URI: ${header.CamelAuditEventUri}"/>
+      <log loggingLevel="INFO" message="Fixity check event URI: ${header.CamelAuditEventUri}"/>
       <process ref="fixityAuditSparqlProcessor"/>
       <!-- produces an N-Triples formatted RDF document using the PREMIS vocabulary to describe the fixity check -->
       <to uri="activemq:queue:triplestore.audit.data"/>
@@ -154,10 +154,22 @@
 
     <route id="edu.umd.lib.camel.routes.FixityNotify">
       <from uri="direct:fixity.notify"/>
-      <!--
-      <to uri="smtp://localhost?To=lib-fcrepo-notify@umd.edu&amp;From=fedora@{{fcrepo.server}}&amp;Subject=Fixity%20Failure"/>
-      -->
-      <to uri="activemq:queue:fixity.notify.result"/>
+      <removeHeaders pattern="*" excludePattern="CamelFcrepoUri"/>
+      <setHeader headerName="To">
+        <constant>lib-fcrepo-notify@umd.edu</constant>
+      </setHeader>
+      <setHeader headerName="From">
+        <simple>fcrepo@${bean:repoExternalURL.host}</simple>
+      </setHeader>
+      <setHeader headerName="Subject">
+        <simple>[${bean:repoExternalURL.host}] Fixity Check Failure: ${header.CamelFcrepoUri}</simple>
+      </setHeader>
+      <setHeader headerName="Content-Type">
+        <constant>text/plain</constant>
+      </setHeader>
+      <routingSlip>
+        <simple>smtp://${sysenv.SMTP_SERVER}</simple>
+      </routingSlip>
     </route>
 
   </camelContext>

--- a/activemq/conf/camel/fixity.xml
+++ b/activemq/conf/camel/fixity.xml
@@ -87,6 +87,12 @@
         <setHeader headerName="Accept">
           <constant>application/rdf+xml</constant>
         </setHeader>
+        <setHeader headerName="X-Forwarded-Host">
+          <simple>${bean:repoExternalURL.authority}</simple>
+        </setHeader>
+        <setHeader headerName="X-Forwarded-Proto">
+          <simple>${bean:repoExternalURL.protocol}</simple>
+        </setHeader>
         <removeHeaders pattern="CamelFcrepo*" excludePattern="CamelFcrepoUri"/>
         <setBody>
           <constant/>
@@ -146,10 +152,12 @@
       <from uri="direct:fixity.log"/>
       <process ref="fixityLogSparqlProcessor"/>
       <setHeader headerName="CamelFileName">
-        <simple>${sysenv.FIXITY_LOG_DIR}/fixity.log</simple>
+        <groovy><![CDATA[
+        import java.text.SimpleDateFormat
+        (new SimpleDateFormat("yyyy-MM-dd-'fixity.log'")).format(new Date())
+        ]]></groovy>
       </setHeader>
-      <!-- to uri="file://?fileExist=Append"/ -->
-      <to uri="activemq:queue:fixity.log.result"/>
+      <to uri="file:///var/log/fixity?fileExist=Append"/>
     </route>
 
     <route id="edu.umd.lib.camel.routes.FixityNotify">

--- a/activemq/conf/camel/triplestore.xml
+++ b/activemq/conf/camel/triplestore.xml
@@ -3,10 +3,6 @@
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
   http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
 
-  <bean id="repoExternalURL" class="java.net.URL">
-    <constructor-arg value="${REPO_EXTERNAL_URL}"/>
-  </bean>
-
   <bean id="descriptionURI" class="edu.umd.lib.camel.processors.DescriptionURI"/>
 
   <camelContext xmlns="http://camel.apache.org/schema/spring" id="Triplestore" streamCache="true">

--- a/activemq/pom.xml
+++ b/activemq/pom.xml
@@ -94,6 +94,11 @@
       <artifactId>camel-solr</artifactId>
       <version>${camel.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.apache.camel</groupId>
+      <artifactId>camel-mail</artifactId>
+      <version>${camel.version}</version>
+    </dependency>
 
     <dependency>
       <groupId>edu.umd.lib</groupId>

--- a/mail/Dockerfile
+++ b/mail/Dockerfile
@@ -1,0 +1,13 @@
+# Dockerfile for a local debugging SMTP server
+#
+# To build:
+#
+# docker build -t docker.lib.umd.edu/fcrepo-mail:<VERSION> -f Dockerfile .
+#
+# where <VERSION> is the Docker image version to create.
+
+FROM python:3.6.8-slim-stretch
+ENV PYTHONUNBUFFERED 1
+EXPOSE 8025
+RUN pip install aiosmtpd
+ENTRYPOINT [ "python", "-m", "aiosmtpd", "-l", "0.0.0.0:8025", "stdout" ]

--- a/mail/README.md
+++ b/mail/README.md
@@ -1,0 +1,24 @@
+# SMTP Mail Server Image for umd-fcrepo-docker
+
+Uses the [Python Docker base image](https://hub.docker.com/_/python/) and
+the [aiosmtpd] Python library to run a dummy SMTP server that just echoes
+the messages to STDOUT.
+
+[Dockerfile](Dockerfile)
+
+Build and run this image.
+
+```bash
+docker build -t docker.lib.umd.edu/fcrepo-mail .
+docker run -it --rm --name fcrepo-mail \
+    -p 8025:8025 \
+    docker.lib.umd.edu/fcrepo-mail
+```
+
+To monitor emails when running this image:
+
+```bash
+docker log -f fcrepo-mail
+```
+
+[aiosmtpd]: https://aiosmtpd.readthedocs.io/en/latest/README.html

--- a/umd-fcrepo.yml
+++ b/umd-fcrepo.yml
@@ -28,6 +28,7 @@ services:
       - JWT_SECRET
       - REPO_EXTERNAL_URL=http://localhost:8080/rest
       - REPO_INTERNAL_URL=http://repository:8080/rest
+      - SMTP_SERVER=mail:8025
   solr-fedora4:
     image: docker.lib.umd.edu/fcrepo-solr-fedora4
     volumes:
@@ -66,6 +67,11 @@ services:
       - MODESHAPE_DB_URL=jdbc:postgresql://postgres:5432/fcrepo_modeshape5
       - MODESHAPE_DB_USERNAME=fcrepo
       - MODESHAPE_DB_PASSWORD
+  mail:
+    # debugging mail server for local development
+    image: docker.lib.umd.edu/fcrepo-mail
+    ports:
+      - 8025:8025
 
 configs:
   ip-mapping.properties:

--- a/umd-fcrepo.yml
+++ b/umd-fcrepo.yml
@@ -10,6 +10,7 @@ services:
     image: docker.lib.umd.edu/fcrepo-activemq
     volumes:
       - activemq-data:/var/opt/activemq
+      - fixity-log-data:/var/log/fixity
     ports:
       - 61616:61616
       - 61613:61613
@@ -79,6 +80,7 @@ configs:
 volumes:
   postgres-data:
   activemq-data:
+  fixity-log-data:
   solr-fedora4-data:
   fuseki-data:
   repository-data:


### PR DESCRIPTION
- created a volume for the fixity log files
- log fixity results to a log file named by the current date

https://issues.umd.edu/browse/LIBFCREPO-912