### PR TITLE
LIBFCREPO-607. Updates to queue names.

### DIFF
--- a/activemq/conf/camel/audit.xml
+++ b/activemq/conf/camel/audit.xml
@@ -13,9 +13,16 @@
 
   <camelContext xmlns="http://camel.apache.org/schema/spring" id="Auditing" streamCache="true">
 
-    <!-- input message format: fcrepo event -->
+    <!--
+    Expected headers:
+    * CamelFcrepoUri
+    * CamelFcrepoEventId
+    * CamelFcrepoEventName
+    Expected environment variables:
+    * AUDIT_EVENT_BASE_URI
+    -->
     <route id="edu.umd.lib.camel.routes.Audit">
-      <from uri="activemq:queue:fedoraaudit"/>
+      <from uri="activemq:queue:audit"/>
       <log loggingLevel="DEBUG" message="Receiving audit event for ${header.CamelFcrepoUri}"/>
       <setHeader headerName="CamelAuditEventUri">
         <simple>${sysenv.AUDIT_EVENT_BASE_URI}${header.CamelFcrepoEventId}</simple>
@@ -61,10 +68,18 @@
       <log loggingLevel="DEBUG" message="Event type for PREMIS: ${header.CamelAuditEventType}"/>
       <multicast parallelProcessing="true">
         <to uri="direct:generatePremis"/>
-        <to uri="activemq:queue:audit.data"/>
+        <to uri="activemq:queue:audit.database"/>
       </multicast>
     </route>
 
+    <!--
+    Expected headers:
+    * CamelAuditEventUri
+    * CamelFcrepoDateTime
+    * CamelFcrepoUser
+    * CamelFcrepoUserAgent
+    * CamelAuditEventType
+    -->
     <route id="edu.umd.lib.camel.routes.GeneratePremis">
       <from uri="direct:generatePremis"/>
       <setBody>
@@ -80,11 +95,23 @@
 <${header.CamelAuditEventUri}> <http://www.loc.gov/premis/rdf/v1#hasEventType> <${header.CamelAuditEventType}> .
         ]]></simple>
       </setBody>
-      <to uri="activemq:queue:triplestore.audit.data"/>
+      <to uri="activemq:queue:audit.triplestore"/>
     </route>
 
+    <!--
+    Expected headers:
+    * CamelAuditEventUri
+    * CamelAuditEventType
+    * CamelFcrepoUser
+    * CamelFcrepoUri
+    * CamelFcrepoDateTime
+    Expected body format:
+    * (None)
+    Expected beans:
+    * auditDatabase : javax.sql.DataSource
+    -->
     <route id="edu.umd.lib.camel.routes.AuditDatabase">
-      <from uri="activemq:queue:audit.data"/>
+      <from uri="activemq:queue:audit.database"/>
       <setBody>
         <constant><![CDATA[
           INSERT INTO history (event_uri, event_type, username, resource_uri, timestamp)
@@ -94,9 +121,16 @@
       <to uri="jdbc:auditDatabase?useHeadersAsParameters=true"/>
     </route>
 
-    <!-- expects an application/n-triples formatted body -->
+    <!--
+    Expected headers:
+    * (None)
+    Expected body format:
+    * application/n-triples
+    Expected environment variables:
+    * AUDIT_TRIPLESTORE_UPDATE_URI
+    -->
     <route id="edu.umd.lib.camel.routes.AuditTriplestore">
-      <from uri="activemq:queue:triplestore.audit.data"/>
+      <from uri="activemq:queue:audit.triplestore"/>
       <removeHeaders pattern="*"/>
       <setHeader headerName="Content-Type">
         <constant>application/sparql-update</constant>

--- a/activemq/conf/camel/fixity.xml
+++ b/activemq/conf/camel/fixity.xml
@@ -63,8 +63,20 @@
   <!-- must enable stream caching since multiple downstream endpoints need to each read the message body in parallel -->
   <camelContext xmlns="http://camel.apache.org/schema/spring" id="FixityChecking" streamCache="true">
 
+    <!--
+    Expects headers:
+    * CamelFcrepoPath
+    * CamelFcrepoUri
+
+    Expects environment variables:
+    * REPO_INTERNAL_URL
+
+    Expects beans:
+    * addBearerAuthorization : edu.umd.lib.camel.processors.AddBearerAuthorizationProcessor
+    * repoExternalURL : java.net.URL
+    -->
     <route id="edu.umd.lib.camel.routes.FixityChecker">
-      <from uri="activemq:queue:fedorafixity"/>
+      <from uri="activemq:queue:fixity"/>
       <setHeader headerName="CamelHttpUri">
         <simple>${sysenv.REPO_INTERNAL_URL}${header.CamelFcrepoPath}</simple>
       </setHeader>
@@ -131,6 +143,22 @@
       </multicast>
     </route>
 
+    <!--
+    Expects headers:
+    * (None)
+
+    Expects body format:
+    * application/rdf+xml
+
+    Expects environment variables:
+    * AUDIT_EVENT_BASE_URI
+
+    Expects beans:
+    * fixityAuditSparqlProcessor : edu.umd.lib.camel.processors.SparqlQueryProcessor
+
+    Produces body format:
+    * application/n-triples
+    -->
     <route id="edu.umd.lib.camel.routes.FixityAudit">
       <from uri="direct:fixity.audit"/>
       <setHeader headerName="CamelAuditEventId">
@@ -145,9 +173,22 @@
       <log loggingLevel="INFO" message="Fixity check event URI: ${header.CamelAuditEventUri}"/>
       <process ref="fixityAuditSparqlProcessor"/>
       <!-- produces an N-Triples formatted RDF document using the PREMIS vocabulary to describe the fixity check -->
-      <to uri="activemq:queue:triplestore.audit.data"/>
+      <to uri="activemq:queue:audit.triplestore"/>
     </route>
 
+    <!--
+    Expects headers:
+    * (None)
+
+    Expects body format:
+    * application/rdf+xml
+
+    Expects beans:
+    * fixityLogSparqlProcessor : edu.umd.lib.camel.processors.SparqlQueryProcessor
+
+    Produces body format:
+    * text/csv
+    -->
     <route id="edu.umd.lib.camel.routes.FixityLog">
       <from uri="direct:fixity.log"/>
       <process ref="fixityLogSparqlProcessor"/>
@@ -160,6 +201,16 @@
       <to uri="file:///var/log/fixity?fileExist=Append"/>
     </route>
 
+    <!--
+    Expects headers:
+    * CamelFcrepoUri
+
+    Expects environment variables:
+    * SMTP_SERVER
+
+    Expects beans:
+    * repoExternalURL : java.net.URL
+    -->
     <route id="edu.umd.lib.camel.routes.FixityNotify">
       <from uri="direct:fixity.notify"/>
       <removeHeaders pattern="*" excludePattern="CamelFcrepoUri"/>
@@ -175,6 +226,8 @@
       <setHeader headerName="Content-Type">
         <constant>text/plain</constant>
       </setHeader>
+      <!-- use a routing slip instead of a simple <to> element
+           for runtime configuration of the SMTP server address -->
       <routingSlip>
         <simple>smtp://${sysenv.SMTP_SERVER}</simple>
       </routingSlip>

--- a/activemq/conf/camel/indexing.xml
+++ b/activemq/conf/camel/indexing.xml
@@ -17,8 +17,8 @@
         <otherwise>
           <log loggingLevel="DEBUG" message="Sending to all indexing destinations"/>
           <multicast parallelProcessing="true">
-            <to uri="activemq:queue:fedoratriplestore"/>
-            <to uri="activemq:queue:fedorasolr"/>
+            <to uri="activemq:queue:index.triplestore"/>
+            <to uri="activemq:queue:index.solr"/>
           </multicast>
         </otherwise>
       </choice>

--- a/activemq/conf/camel/routes.xml
+++ b/activemq/conf/camel/routes.xml
@@ -7,6 +7,20 @@
 
   <camelContext xmlns="http://camel.apache.org/schema/spring" id="UmdFcrepoEventRouter" streamCache="true">
 
+    <!--
+    Expected headers:
+    * org.fcrepo.jms.user
+    * org.fcrepo.jms.userAgent
+    * org.fcrepo.jms.eventType
+    * org.fcrepo.jms.resourceType
+    * org.fcrepo.jms.identifier
+
+    Expected body format:
+    * application/json OR Java Map
+
+    Expected environment variables:
+    * BATCH_USER
+    -->
     <route id="edu.umd.lib.camel.routes.FedoraEvents">
       <from uri="activemq:queue:fedora"/>
       <process ref="eventProcessor"/>
@@ -51,6 +65,10 @@
       </choice>
     </route>
 
+    <!--
+    Expected headers:
+    * CamelFcrepoPath
+    -->
     <route id="edu.umd.lib.camel.routes.BatchEvents">
       <from uri="direct:batch"/>
       <filter>
@@ -67,6 +85,10 @@
       <to uri="direct:detectEventType"/>
     </route>
 
+    <!--
+    Expected headers:
+    * CamelFcrepoEventType
+    -->
     <route id="edu.umd.lib.camel.routes.DetectEventType">
       <from uri="direct:detectEventType"/>
       <log loggingLevel="DEBUG" message="${routeId}: ${id}"/>
@@ -102,6 +124,11 @@
       <to uri="direct:detectBinary"/>
     </route>
 
+    <!--
+    Expected headers:
+    * CamelFcrepoResourceType
+    * CamelFcrepoEventName
+    -->
     <route id="edu.umd.lib.camel.routes.DetectBinary">
       <from uri="direct:detectBinary"/>
       <choice>
@@ -124,7 +151,10 @@
       <to uri="direct:distribution"/>
     </route>
 
-    <!-- TODO: document the message formats at context boundaries -->
+    <!--
+    Expected headers:
+    * CamelFcrepoUri
+    -->
     <route id="edu.umd.lib.camel.routes.Distribution">
       <from uri="direct:distribution"/>
       <log loggingLevel="DEBUG" message="Distributing event for ${header.CamelFcrepoUri} (MessageID: ${id})"/>
@@ -134,10 +164,15 @@
           <to uri="direct:binary"/>
         </filter>
         <to uri="activemq:queue:index"/>
-        <to uri="activemq:queue:fedoraaudit"/>
+        <to uri="activemq:queue:audit"/>
       </multicast>
     </route>
 
+    <!--
+    Expected headers:
+    * CamelFcrepoEventName
+    * CamelFcrepoUri
+    -->
     <route id="edu.umd.lib.camel.routes.Binaries">
       <from uri="direct:binary"/>
       <multicast parallelProcessing="true">
@@ -156,7 +191,7 @@
           <to uri="activemq:queue:fixitycandidates"/>
         </filter>
         <!-- send to fixity processing -->
-        <to uri="activemq:queue:fedorafixity"/>
+        <to uri="activemq:queue:fixity"/>
       </multicast>
     </route>
 

--- a/activemq/conf/camel/solr.xml
+++ b/activemq/conf/camel/solr.xml
@@ -124,7 +124,7 @@ issue_title_facet = .[rdf:type is bibo:Issue]/dcterms:title | pcdm:memberOf[rdf:
 
   <camelContext xmlns="http://camel.apache.org/schema/spring" id="SolrIndex" streamCache="true"><!-- errorHandlerRef="deadLetterErrorHandler" -->
     <route id="edu.umd.lib.camel.routes.SolrIndexing">
-      <from uri="activemq:queue:fedorasolr"/>
+      <from uri="activemq:queue:index.solr"/>
       <choice>
         <when>
           <simple>
@@ -138,11 +138,6 @@ issue_title_facet = .[rdf:type is bibo:Issue]/dcterms:title | pcdm:memberOf[rdf:
           <to uri="direct:solr.index"/>
         </otherwise>
       </choice>
-    </route>
-
-    <route id="edu.umd.lib.camel.routes.SolrReindexing">
-      <from uri="activemq:queue:solr.reindex"/>
-      <to uri="direct:solr.index"/>
     </route>
 
     <route id="edu.umd.lib.camel.routes.InsertIntoSolr">

--- a/activemq/conf/camel/triplestore.xml
+++ b/activemq/conf/camel/triplestore.xml
@@ -13,7 +13,7 @@
     * (None)
     -->
     <route id="edu.umd.lib.camel.routes.TriplestoreIndexing">
-      <from uri="activemq:queue:fedoratriplestore"/>
+      <from uri="activemq:queue:index.triplestore"/>
       <choice>
         <when>
           <simple>${header.CamelFcrepoEventName} starts with "create"</simple>


### PR DESCRIPTION
- Removed redundant "fedora" from indexing queue names
- Use a more consistent dotted notation for queue names
- Added some inline XML comment documentation of the routes

https://issues.umd.edu/browse/LIBFCREPO-607