### PR TITLE
LIBFCREPO-935. Added plastrond container to the stack.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 activemq/data/
 */jars/*.jar
+.env

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Docker images for the Fedora (fcrepo) applications.
 ## External Requirements
 
 * [umd-fcrepo-webapp] Docker image
+* [plastrond] Docker image
 
 ## Quick Start
 
@@ -23,7 +24,7 @@ docker build -t docker.lib.umd.edu/fcrepo-fixity fixity
 docker build -t docker.lib.umd.edu/fcrepo-mail mail
 ```
 
-Export environment variables (for the repository container):
+Export environment variables:
 
 ```bash
 export MODESHAPE_DB_PASSWORD=...  # default in the umd-fcrepo-docker stack is "fcrepo"
@@ -38,6 +39,15 @@ Deploy the stack:
 ```bash
 docker stack deploy --with-registry-auth -c umd-fcrepo.yml umd-fcrepo
 ```
+
+For ease of deploying, you can create a `.env` file that exports the required
+environment variables and, source that file when deploying:
+
+```bash
+source .env && docker stack deploy --with-registry-auth -c umd-fcrepo.yml umd-fcrepo
+```
+
+Any `.env` file will be ignored by Git.
 
 ### Fixity checking
 
@@ -124,4 +134,5 @@ files for each image for more information:
 * [Mail](mail/README.md)
 
 [umd-fcrepo-webapp]: https://github.com/umd-lib/umd-fcrepo-webapp
+[plastrond]: https://github.com/umd-lib/plastron
 [aiosmtpd]: https://aiosmtpd.readthedocs.io/en/latest/README.html

--- a/plastrond/plastrond.yml
+++ b/plastrond/plastrond.yml
@@ -1,0 +1,17 @@
+REPOSITORY:
+  REST_ENDPOINT: http://repository:8080/rest
+  RELPATH: /pcdm
+  STRUCTURE: hierarchical
+  JWT_SECRET: ${JWT_SECRET}
+  LOG_DIR: logs
+MESSAGE_BROKER:
+  SERVER: activemq:61613
+  MESSAGE_STORE_DIR: /var/opt/plastron/msg
+  DESTINATIONS:
+    JOBS: /queue/plastron.jobs
+    JOB_STATUS: /topic/plastron.jobs.status
+    COMPLETED_JOBS: /queue/plastron.jobs.completed
+    SYNCHRONOUS_JOBS: /queue/plastron.jobs.synchronous
+COMMANDS:
+  EXPORT:
+    SSH_PRIVATE_KEY:

--- a/umd-fcrepo.yml
+++ b/umd-fcrepo.yml
@@ -96,6 +96,15 @@ services:
       - MODESHAPE_DB_URL=jdbc:postgresql://modeshape-db:5432/fcrepo_modeshape5
       - MODESHAPE_DB_USERNAME=fcrepo
       - MODESHAPE_DB_PASSWORD
+  plastrond:
+    image: docker.lib.umd.edu/plastrond
+    configs:
+      - source: plastrond.yml
+        target: /etc/plastrond.yml
+    volumes:
+      - plastrond-data:/var/opt/plastron/msg
+    environment:
+      - JWT_SECRET
   mail:
     # debugging mail server for local development
     image: docker.lib.umd.edu/fcrepo-mail
@@ -111,6 +120,8 @@ configs:
     file: ./postgres-modeshape/init-modeshape-db.sh
   ip-mapping.properties:
     file: ./repository/ip-mapping.properties
+  plastrond.yml:
+    file: ./plastrond/plastrond.yml
 volumes:
   archelon-db-data:
   audit-db-data:
@@ -120,3 +131,4 @@ volumes:
   solr-fedora4-data:
   fuseki-data:
   repository-data:
+  plastrond-data:


### PR DESCRIPTION
Added instructions in the README about creating a .env file and using it when deploying the stack.

https://issues.umd.edu/browse/LIBFCREPO-935