### PR TITLE
LIBFCREPO-991. Only index edm:hasType as component field if it has an rdfs:label child.

### DIFF
--- a/activemq/conf/camel/solr.xml
+++ b/activemq/conf/camel/solr.xml
@@ -120,7 +120,7 @@ resource_selector = oa:hasTarget/oa:hasSelector[rdf:type is oa:FragmentSelector]
 
 issue_title_facet = .[rdf:type is bibo:Issue]/dcterms:title | pcdm:memberOf[rdf:type is bibo:Issue]/dcterms:title :: xsd:string;
 
-component = fn:first(edm:hasType/rdfs:label, edm:hasType) :: xsd:string;
+component = edm:hasType/rdfs:label :: xsd:string;
       ]]></value>
     </property>
   </bean>


### PR DESCRIPTION
https://issues.umd.edu/browse/LIBFCREPO-991