### PR TITLE
LIBFCREPO-1028. Set AUDIT_DB_PORT to 5432

### DIFF
--- a/umd-fcrepo.yml
+++ b/umd-fcrepo.yml
@@ -44,7 +44,7 @@ services:
       - 8161:8161
     environment:
       - AUDIT_DB_HOST=audit-db
-      - AUDIT_DB_PORT=5433
+      - AUDIT_DB_PORT=5432
       - AUDIT_DB_NAME=fcrepo_audit
       - AUDIT_DB_USERNAME=camel
       - AUDIT_DB_PASSWORD=camel


### PR DESCRIPTION
The "5433" port is used to access the "audit-db" database from outside
the Docker stack. The "activemq" instance, however, is running in a
Docker container, and using Docker networking to communicate with the
"audit-db" database, so the internal "5432" port should be used.

https://issues.umd.edu/browse/LIBFCREPO-1028