### PR TITLE
LIBFCREPO-1037. Plastron daemon web service.

### DIFF
--- a/plastron/plastron.yml
+++ b/plastron/plastron.yml
@@ -4,7 +4,7 @@ REPOSITORY:
   RELPATH: /pcdm
   JWT_SECRET: ${JWT_SECRET}
   LOG_DIR: /var/log/plastron
-  JOB_DIR: /var/opt/plastron/jobs
+  JOBS_DIR: /var/opt/plastron/jobs
 MESSAGE_BROKER:
   SERVER: activemq:61613
   MESSAGE_STORE_DIR: /var/opt/plastron/msg
@@ -18,3 +18,4 @@ COMMANDS:
     SSH_PRIVATE_KEY: /etc/plastron/auth/archelon_id
   IMPORT:
     SSH_PRIVATE_KEY: /etc/plastron/auth/archelon_id
+    JOBS_DIR: /var/opt/plastron/jobs

--- a/plastrond.yml
+++ b/plastrond.yml
@@ -11,7 +11,10 @@ services:
         target: /etc/plastron/auth/archelon_id
         mode: 0400
     volumes:
-      - plastrond:/var/opt/plastron
+      - plastrond-jobs:/var/opt/plastron/jobs
+      - plastrond-messages:/var/opt/plastron/msg
+    ports:
+      - 5000:5000
 configs:
   archelon_id:
     # Private key for archelon SFTP
@@ -20,4 +23,5 @@ configs:
   plastrond:
     file: ./plastron/plastron.yml
 volumes:
-  plastrond:
+  plastrond-jobs:
+  plastrond-messages:


### PR DESCRIPTION
- configure JOBS_DIR path in the plastron.yml configuration
- map port 5000 to 5000
- split the plastrond volume into plastrond-jobs and plastrond-messages

https://issues.umd.edu/browse/LIBFCREPO-1037